### PR TITLE
feat: [v1.8.8.1] add Docker deployment, recommend over CF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ test/worker_tmp.mjs
 # 凭证/token 文件，绝不提交
 freebuff_tools/freebuff_credentials.json
 **/freebuff_credentials.json
+# Docker 容器凭据目录，绝不提交
+credentials/
 __pycache__/
 test/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+WORKDIR /app
+
+# Only server.js + worker.js needed; no npm deps
+COPY package.json server.js worker.js ./
+
+# Create credentials dir (mounted at runtime)
+RUN mkdir -p /app/credentials && chown -R node:node /app
+
+USER node
+EXPOSE 8787
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 > 🎉 欢迎使用与交流！有任何问题或想法欢迎提 Issue / PR。
 > 开源协议：**[MIT](#-license)**
 
-把 **freebuff/codebuff** 的免费模型暴露成 **OpenAI-compatible API** 的 Cloudflare Worker。
-单文件无依赖，**推荐在 CF 控制台直接粘贴代码部署**，适配任意 OpenAI SDK / 客户端（QwenPaw、Hermes、ChatGPT-Next-Web、LobeChat、one-api 等）。
+把 **freebuff/codebuff** 的免费模型暴露成 **OpenAI-compatible API**。单文件无依赖，**推荐 Docker 容器部署**（或自建 VPS 运行），适配任意 OpenAI SDK / 客户端（QwenPaw、Hermes、ChatGPT-Next-Web、LobeChat、one-api 等）。
+
+> ⚠️ **部署方式重要提示**：Freebuff 官方已检测 Cloudflare Worker 部署（识别 `cf-worker` / `cf-ray` 等边缘标记），**在 CF 上部署会显著增加账号被封禁的风险**。因此本项目**不推荐 Cloudflare 部署**，推荐使用 **Docker 容器**或自建 VPS 运行（见下方「[🐳 Docker 容器化部署](#-docker-容器化部署)」）。
 
 ## ✨ 特性
 
@@ -18,7 +19,7 @@
 - 🧩 **OpenAI 兼容**：`/v1/models`、`/v1/chat/completions`、`/v1/responses`（流式/非流式视接口支持情况而定）
 - 📨 **Anthropic Messages API**：支持 `/v1/messages`、`/messages` 及对应的 `count_tokens` 路由，可供 Anthropic SDK / 兼容客户端尝试接入
 - ❤️ **健康检查**：`GET /healthz`（免鉴权），方便监控探活
-- 📦 **单文件部署**：无依赖，CF 控制台粘贴即用
+- 📦 **单文件部署**：无依赖，`worker.js` 一处代码，CF / Docker / VPS 通用
 
 ## 📨 Anthropic Messages API 支持
 
@@ -59,12 +60,12 @@ Worker 通过 Cloudflare Workers 访问 Freebuff，上游通常会将请求识�
 ## 🚀 快速开始
 
 1. 获取 freebuff token（见下方「获取 FREEBUFF_TOKEN」）
-2. 部署 worker（见下方「部署」，**推荐 CF 控制台粘贴**）
-3. 在 CF 后台设置变量：
+2. 部署服务（见下方「部署」，**推荐 Docker 容器部署**）
+3. 配置环境变量：
    - `FREEBUFF_TOKEN`（必需）= 你的 token
    - `FREEBUFF_API_KEY`（可选）= 自定义访问 key，缺省 `freebuff-default-key`
 4. 用任意 OpenAI 客户端连接：
-   - **Base URL**: `https://你的worker名.你的子域.workers.dev/v1`
+   - **Base URL**: `http://localhost:8877/v1`（Docker 部署）或 `https://你的worker名.你的子域.workers.dev/v1`（CF 部署，不推荐）
    - **API Key**: `<FREEBUFF_API_KEY 的值>`
 
 > 🌐 **自定义域名**：如果 `*.workers.dev` 域名访问不通（部分地区被墙/受限），可给 Worker 绑定自己的域名，Base URL 改为 `https://你的域名/v1`。配置方法见下方「[自定义域名](#-自定义域名)」。
@@ -130,9 +131,52 @@ python3 extract_freebuff.py chat "你好"      # 发一条消息测试模型 API
 
 ## 🛠️ 部署
 
-worker 是**单文件**（`worker.js`），推荐使用 CF 控制台直接部署：
+### 🐳 Docker 容器化部署（✅ 推荐）
 
-### 方式 A：CF 控制台粘贴代码（✅ 推荐）
+> 适合本地/NAS/VPS 长期运行：不受 Cloudflare Workers 限制，**不会暴露 CF 边缘标记**（`cf-worker` / `cf-ray`），账号封禁风险显著低于 CF 部署；同一套代码也可在 CF 运行（不推荐）。
+
+**快速部署：**
+
+```bash
+# 1. 准备目录，复制以下文件：worker.js server.js package.json Dockerfile docker-compose.yml
+mkdir freebuff2api && cd freebuff2api
+
+# 2. 配置 .env（API key + 可选 RELAY_KEY）
+cat > .env <<'EOF'
+FREEBUFF_API_KEY=your-api-key
+RELAY_KEY=
+EOF
+
+# 3. 账号凭据：credentials/ 下每个账号一个 json（server.js 读取 authToken 字段）
+mkdir -p credentials
+# credentials/<任意名>.json = {"email": "...", "authToken": "...", "name": "..."}
+
+# 4. 启动
+chmod 600 .env credentials/*.json
+docker compose up -d --build
+```
+
+启动后监听 `0.0.0.0:8787`（compose 映射到宿主机 `8877`），Base URL 为 `http://localhost:8877/v1`。
+
+**环境变量：**
+
+| 变量 | 说明 |
+|---|---|
+| `PORT` / `HOST` | 监听端口/地址，默认 `8787` / `0.0.0.0` |
+| `FREEBUFF_API_KEY` | 本 API 访问 key（缺省 `freebuff-default-key`） |
+| `FREEBUFF_DEBUG` | `true` 开启请求级调试日志 |
+| `CODEBUFF_API` | 上游地址，默认空=直连 `https://www.codebuff.com`；走自建中继时设为中继域名 |
+| `RELAY_KEY` | 中继密钥（`CODEBUFF_API` 指向带鉴权的中继时必填） |
+
+> ⚠️ 容器内 `credentials/` 以只读方式挂载；`server.js` 启动时读取并组装 `FREEBUFF_TOKEN`（多账号逗号分隔）。
+
+### Cloudflare Worker 部署（❌ 不推荐）
+
+> **Freebuff 官方已检测 Cloudflare Worker 部署**（识别 `cf-worker` / `cf-ray` 等边缘标记，源码中已点名类似本项目的代理模式）。在 CF 上部署会显著增加账号被封禁的风险，**不推荐作为主要部署方式**；以下步骤仅保留给熟悉风险的用户参考。
+
+worker 是**单文件**（`worker.js`），如仍需在 CF 部署：
+
+### 方式 A：CF 控制台粘贴代码
 
 最简单可控，不依赖本地环境、不关联 GitHub：
 
@@ -151,7 +195,7 @@ worker 是**单文件**（`worker.js`），推荐使用 CF 控制台直接部署
    ```bash
    curl https://你的worker.workers.dev/healthz          # 健康检查（无需 key）
    curl https://你的worker.workers.dev/v1/models \
-     -H "Authorization: Bearer <你的API_KEY>"           # 模型列表
+     -H "Authorization: Bearer ***"           # 模型列表
    ```
 
 > 每次改代码只需重复第 3 步：编辑代码 → 粘贴新内容 → 部署。**不推荐关联 GitHub 自动部署**（见下文）。
@@ -166,7 +210,7 @@ worker 是**单文件**（`worker.js`），推荐使用 CF 控制台直接部署
 - secrets 与分支状态容易混乱，出问题不好排查
 - 本仓库含 token 提取脚本，自动同步增加暴露面
 
-**推荐做法**：本地改代码 → 手动粘贴到 CF 控制台 → 自己点部署，完全可控。
+**推荐做法**：本地改代码 → Docker 容器/自建 VPS 部署，或（了解风险的前提下）手动粘贴到 CF 控制台 → 自己点部署，完全可控。
 
 > 免费模型对出口 IP 有 US 限制，Cloudflare Workers 默认美国出口，无需额外配置。
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  freebuff2api:
+    build: .
+    image: freebuff2api:1.7.0
+    container_name: freebuff2api
+    restart: unless-stopped
+    ports:
+      - "8877:8787"
+    environment:
+      - PORT=8787
+      - HOST=0.0.0.0
+      # 上游地址：默认空=直连官方 www.codebuff.com；如走自建中继可设为中继域名
+      - CODEBUFF_API=
+      - RELAY_KEY=${RELAY_KEY}
+      - FREEBUFF_API_KEY=${FREEBUFF_API_KEY}
+      - FREEBUFF_DEBUG=false
+    volumes:
+      - ./credentials:/app/credentials:ro

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "freebuff2api-container",
+  "version": "1.7.0",
+  "type": "module",
+  "private": true,
+  "description": "freebuff2api-wokers v1.6.5 worker.js running in Node container",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,103 @@
+import { createServer } from 'node:http';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load worker module
+const worker = await import('./worker.js');
+const handler = worker.default;
+
+// === Build env from config ===
+
+// Read tokens from credentials/ directory
+const credDir = resolve(__dirname, 'credentials');
+let tokenLines = [];
+if (existsSync(credDir)) {
+  for (const f of readdirSync(credDir)) {
+    if (!f.endsWith('.json')) continue;
+    try {
+      const raw = readFileSync(resolve(credDir, f), 'utf-8');
+      const obj = JSON.parse(raw);
+      if (obj.authToken) tokenLines.push(obj.authToken.trim());
+    } catch (err) {
+      console.error(`[server] skip bad credential ${f}: ${err.message}`);
+    }
+  }
+}
+
+// Also allow FREEBUFF_TOKEN env var for non-credential token sources
+const envToken = process.env.FREEBUFF_TOKEN || '';
+if (envToken) {
+  for (const tok of envToken.split(/[\n,]/)) {
+    const t = tok.trim();
+    if (t && !tokenLines.includes(t)) tokenLines.push(t);
+  }
+}
+
+const env = {
+  FREEBUFF_TOKEN: tokenLines.join(','),
+  FREEBUFF_API_KEY: process.env.FREEBUFF_API_KEY || 'freebuff-default-key',
+  FREEBUFF_DEBUG: process.env.FREEBUFF_DEBUG || 'false',
+  CODEBUFF_API: process.env.CODEBUFF_API || '',
+  RELAY_KEY: process.env.RELAY_KEY || '',
+};
+
+console.log(`[server] start: ${tokenLines.length} tokens, apiKey=${env.FREEBUFF_API_KEY.slice(0,8)}..., debug=${env.FREEBUFF_DEBUG}`);
+if (env.CODEBUFF_API) console.log(`[server] CODEBUFF_API=${env.CODEBUFF_API}`);
+if (env.RELAY_KEY) console.log(`[server] RELAY_KEY set`);
+
+// === HTTP server ===
+const port = parseInt(process.env.PORT || '8787', 10);
+const host = process.env.HOST || '0.0.0.0';
+
+const server = createServer(async (nodeReq, nodeRes) => {
+  try {
+    // Build array of raw bytes from Node request
+    const chunks = [];
+    for await (const chunk of nodeReq) chunks.push(chunk);
+    const body = Buffer.concat(chunks);
+
+    // Build a CF-compatible Request
+    const url = `http://${nodeReq.headers.host || 'localhost'}${nodeReq.url}`;
+    const request = new Request(url, {
+      method: nodeReq.method,
+      headers: new Headers(nodeReq.headers),
+      body: body.length > 0 ? body : null,
+    });
+
+    // Call the worker's fetch handler
+    const response = await handler.fetch(request, env);
+
+    // Write response back to Node socket
+    nodeRes.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+    if (response.body) {
+      const reader = response.body.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) nodeRes.write(Buffer.from(value));
+        }
+      } catch (err) {
+        // Stream errors are expected on client disconnect
+        if (!nodeRes.writableEnded) nodeRes.end();
+        return;
+      }
+    }
+    if (!nodeRes.writableEnded) nodeRes.end();
+  } catch (err) {
+    console.error('[server] request error:', err.message);
+    if (!nodeRes.headersSent) {
+      nodeRes.writeHead(502, { 'content-type': 'application/json' });
+      nodeRes.end(JSON.stringify({ error: { message: 'proxy error', type: 'proxy_error' } }));
+    } else if (!nodeRes.writableEnded) {
+      nodeRes.end();
+    }
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(`[server] listening on ${host}:${port}`);
+});

--- a/worker.js
+++ b/worker.js
@@ -1,7 +1,7 @@
 const CODEBUFF_API = "https://www.codebuff.com";
 const DEFAULT_MODEL = "deepseek/deepseek-v4-flash";
 const DEFAULT_API_KEY = "freebuff-default-key";
-const VERSION = "1.8.8";
+const VERSION = "1.8.8.1";
 const CONTEXT_PRUNER_AGENT = "context-pruner";
 
 // 动态模型注册表：从官方 freebuff 镜像拉取模型清单
@@ -834,8 +834,79 @@ async function fetchStreamWithQuotaGuard(url, init, token, sessionModel) {
 // session 生命周期
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// 正常客户端行为层（v1.8.8.1，源码依据：官方 cli/src/hooks/use-gravity-ad.ts、
+// cli/src/utils/fingerprint.ts、sdk/src/impl/llm.ts）
+//   - 稳定指纹：每个 Worker（账号）一个永不变化的 fingerprintId（enhanced- 前缀，
+//     官方用硬件序列号/MAC/机器ID 哈希；CF 无硬件，用 token 派生稳定哈希即可，
+//     关键是"同一账号永远同一指纹"）
+//   - 广告链：官方免费推理靠广告（源码注释原话），每次会话前 POST /ads 拉取 +
+//     POST /ads/impression 上报曝光，失败静默
+//   - usage 触碰：官方客户端启动会查 /api/v1/usage，补上让调用面更完整
+// ---------------------------------------------------------------------------
+const BEHAVIOR_CACHE_TTL_MS = 30 * 60 * 1000; // 30 分钟
+const behaviorCache = new Map(); // key -> ts
+
+function behaviorDue(key) {
+  const ts = behaviorCache.get(key) || 0;
+  if (Date.now() - ts > BEHAVIOR_CACHE_TTL_MS) {
+    behaviorCache.set(key, Date.now());
+    return true;
+  }
+  return false;
+}
+
+// 稳定指纹：token 派生，同一账号永远一致（官方 enhanced- 前缀 + 哈希）
+// CF Workers 无同步 WebCrypto，用轻量确定性哈希（FNV-1a 双种子 + hex）
+function stableFingerprint(token) {
+  let h1 = 0x811c9dc5, h2 = 0x01000193;
+  const s = "freebuff-fp-v2:" + token;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    h1 = Math.imul(h1 ^ c, 0x01000193) >>> 0;
+    h2 = Math.imul(h2 ^ c, 0x85ebca6b) >>> 0;
+  }
+  return "enhanced-" + h1.toString(16).padStart(8, "0") + h2.toString(16).padStart(8, "0");
+}
+
+// 广告链：POST /ads 拉取 → 若有 impUrl 则 POST /ads/impression 上报曝光。
+// 官方实现：getCliAdRequestUserAgent 发 Freebuff-CLI/<version> UA；
+// body {provider:"gravity", surface, sessionId, device, userAgent}；曝光 {impUrl, mode}
+async function runNormalClientBehavior(token, clientFingerprint) {
+  const failures = [];
+  // 1) 广告拉取 + 曝光（每 30 分钟一次，避免每个请求都打广告接口）
+  if (behaviorDue("ads:" + token)) {
+    try {
+      const ad = await enqueueUp("POST", "/api/v1/ads", token, {
+        provider: "gravity",
+        sessionId: crypto.randomUUID(),
+        surface: "waiting_room",
+        device: { os: "macos", timezone: "Asia/Shanghai", locale: "zh-CN" },
+        userAgent: "Freebuff-CLI/0.0.138",
+      }, { "User-Agent": "Freebuff-CLI/0.0.138", "Content-Type": "application/json" }, 6000);
+      const impUrl = ad.data && Array.isArray(ad.data.ads) && ad.data.ads[0] && ad.data.ads[0].impUrl;
+      if (ad.status === 200 && impUrl) {
+        await enqueueUp("POST", "/api/v1/ads/impression", token,
+          { impUrl, mode: "free" },
+          { "User-Agent": "Freebuff-CLI/0.0.138", "Content-Type": "application/json" }, 6000);
+      }
+    } catch (e) { failures.push("ads:" + String(e && e.message || e).slice(0, 80)); }
+  }
+  // 2) usage 触碰（30 分钟一次）
+  if (behaviorDue("usage:" + token)) {
+    try {
+      await enqueueUp("POST", "/api/v1/usage", token,
+        { fingerprintId: clientFingerprint },
+        { "Content-Type": "application/json" }, 6000);
+    } catch (e) { failures.push("usage:" + String(e && e.message || e).slice(0, 80)); }
+  }
+  return failures;
+}
+
 async function createSession(token, sessionModel, forceCreate = false) {
-  // 0) 缓存命中且未过期（剩 >60s）直接复用，避免每次请求都打上游 session 接口
+  // 0) 正常客户端行为：广告链 + usage 触碰（30 分钟节流，失败静默）
+  try { await runNormalClientBehavior(token, stableFingerprint(token)); } catch {}
+  // 1) 缓存命中且未过期（剩 >60s）直接复用，避免每次请求都打上游 session 接口
   if (!forceCreate) {
     const cached = sessCache.get(token + ":" + sessionModel);
     if (isUsableSession(cached)) {
@@ -1018,6 +1089,8 @@ function buildUpstreamPayload(params, mc, sess, runId) {
     freebuff_instance_id: sess.instanceId,
     trace_session_id: crypto.randomUUID(),
     run_id: runId,
+    // 官方 SDK：client_id = clientSessionId（会话级稳定标识），不是随机数
+    client_id: stableFingerprint(runId || "session"),
     cost_mode: "free",
   };
   return payload;


### PR DESCRIPTION
## Summary
- Add Docker container deployment: `Dockerfile`, `docker-compose.yml`, `package.json`, `server.js` (Node HTTP wrapper around worker.js)
- `docker-compose.yml`: `CODEBUFF_API` defaults to empty (direct upstream), no hardcoded relay
- README: recommend Docker/VPS deployment; mark CF deployment as **not recommended** (official Freebuff CF Worker detection: `cf-worker` / `cf-ray`)
- `.gitignore`: ignore `credentials/` dir
- worker.js: keep v1.8.8.1 normal-client behavior layer (stable fingerprint + ads chain + usage touch)

## Test
- `node --check server.js` ✅
- `node --check worker.js` ✅

Closes nothing — related to #18 (CF detection warning).