### PR TITLE
fix(worker): aggregate delta.tool_calls for non-streaming responses

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1770,6 +1770,7 @@ async function streamToNonStream(upstreamBody, upstreamModel) {
   const reader = upstreamBody.getReader();
   const decoder = new TextDecoder();
   let buf = "", content = "", reasoning = "", finishReason = null, model = "", id = "", usage = null;
+  const toolCalls = new Map(); // 上游 tool_calls index -> {id, name, arguments}
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
@@ -1787,6 +1788,19 @@ async function streamToNonStream(upstreamBody, upstreamModel) {
         const delta = choice.delta || {};
         if (delta.content) content += delta.content;
         if (delta.reasoning_content) reasoning += delta.reasoning_content;
+        // 工具调用增量（chat 格式 delta.tool_calls[]）
+        if (Array.isArray(delta.tool_calls)) {
+          for (const tc of delta.tool_calls) {
+            if (!tc || typeof tc !== "object") continue;
+            const ti = tc.index ?? 0;
+            let item = toolCalls.get(ti);
+            if (!item) { item = { id: "", name: "", arguments: "" }; toolCalls.set(ti, item); }
+            if (tc.id) item.id = tc.id;
+            const fn = tc.function || {};
+            if (fn.name && !item.name) item.name = fn.name;
+            if (fn.arguments) item.arguments += fn.arguments;
+          }
+        }
         if (choice.finish_reason) finishReason = choice.finish_reason;
         if (obj.id) id = obj.id;
         if (obj.model) model = obj.model;
@@ -1795,6 +1809,13 @@ async function streamToNonStream(upstreamBody, upstreamModel) {
     }
   }
   const msg = { role: "assistant", content };
+  if (toolCalls.size) {
+    msg.tool_calls = [...toolCalls.entries()].sort((x, y) => x[0] - y[0]).map(([, v]) => ({
+      id: v.id || ("call_" + Math.random().toString(36).slice(2, 10)),
+      type: "function",
+      function: { name: v.name, arguments: v.arguments },
+    }));
+  }
   if (reasoning && !content) { msg.content = reasoning; msg.reasoning_used_as_content = true; }
   else if (reasoning) msg.reasoning_content = reasoning;
   return {


### PR DESCRIPTION
## 背景

非流式请求（`/v1/responses`、`/v1/chat/completions` 带 `stream:false`）时，上游强制流式返回，`streamToNonStream` 只聚合了 `delta.content` / `delta.reasoning_content`，**丢弃了 `delta.tool_calls`**——导致非流式路径下 assistant 消息没有 `tool_calls`，客户端（如 Codex 走 responses 非流式 + 工具调用）无法执行工具。

## 改动

`streamToNonStream` 按 `delta.tool_calls[].index` 增量聚合 `id` / `name` / `arguments`，按 index 排序后组装进 assistant message 的 `tool_calls`。

## 验证

- 本地 server.js 实测：非流式 responses + 工具调用可正常返回 `tool_calls`
- 不改变流式路径与上游调用链

## 影响

仅影响非流式路径的响应组装；流式、chat 流式、Anthropic Messages API 均不受影响。